### PR TITLE
Fix php image conf overwritten in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
             - debian
         volumes:
             - './:/var/www/smartfact:rw'
-            - './docker/php/conf/:/usr/local/etc/php/'
 
     # DB configuration
     mongodb:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -22,10 +22,9 @@ RUN apt-get update -y \
     && mv phpunit-6.1.phar /usr/local/bin/phpunit \
     && phpunit --version
 
-RUN mkdir -p /usr/local/etc/php/conf.d/
+COPY conf/php.ini /usr/local/etc/php/
 
-RUN docker-php-ext-install pdo_mysql \
-    && docker-php-ext-enable pdo_mysql.so
+RUN docker-php-ext-install pdo_mysql
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 


### PR DESCRIPTION
Pour que ton conteneur utilise ton php.ini custom, tu fais ça dans le docker-compose.yml:
~~~yaml
volumes:
  - './docker/php/conf/:/usr/local/etc/php/'
~~~
Ça a pour effet d'écraser entièrement le `/usr/local/etc/php/' de ton image. Pourtant c'est là que se trouve la conf utilisateur, et donc le ini de ton extension pdo_mysql. Voilà pourquoi il la trouvait pas. J'ai donc remplacé ça par une simple copie du php.ini directement dans l'image (voir Dockerfile).